### PR TITLE
Add support to configure the webGui port

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,3 +8,6 @@ inactivity_limit = 3600
 [template_distribution_config]
 server_addr = "127.0.0.1:8442"
 # auth_pk = "9bwHCYnjhbHm4AS3pWg9MtAH83mzWohoJJJDELYBqZhDNqszDLc"
+
+[web_config]
+listening_port = 1337

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,9 +25,15 @@ pub struct PlebLotteryTemplateDistributionClientConfig {
 }
 
 #[derive(Clone, Deserialize, Debug)]
+pub struct PlebLotteryWebConfig {
+    pub listening_port: u16,
+}
+
+#[derive(Clone, Deserialize, Debug)]
 pub struct PleblotteryConfig {
     pub mining_server_config: PlebLotteryMiningServerConfig,
     pub template_distribution_config: PlebLotteryTemplateDistributionClientConfig,
+    pub web_config: PlebLotteryWebConfig,
 }
 
 impl PleblotteryConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,11 @@ async fn main() -> anyhow::Result<()> {
 
     pleblottery_service.start().await?;
 
-    start_web_server().await?;
-    info!("Web server started on http://localhost:8000");
+    start_web_server(&config.web_config).await?;
+    info!(
+        "Web server started on http://localhost:{}",
+        config.web_config.listening_port
+    );
 
     // Wait for Ctrl+C
     tokio::signal::ctrl_c().await?;

--- a/src/web/server.rs
+++ b/src/web/server.rs
@@ -3,15 +3,17 @@ use axum::Router;
 use tokio::net::TcpListener;
 use tower_http::services::ServeDir;
 
+use crate::config::PlebLotteryWebConfig;
 use crate::web::routes::{api::api_routes, html::html_routes};
 
-pub async fn start_web_server() -> Result<()> {
+pub async fn start_web_server(web_config: &PlebLotteryWebConfig) -> Result<()> {
     let app = Router::new()
         .nest_service("/static", ServeDir::new("src/web/assets"))
         .merge(html_routes())
         .merge(api_routes());
 
-    let listener = TcpListener::bind("0.0.0.0:8000").await?;
+    let addr = format!("0.0.0.0:{}", web_config.listening_port);
+    let listener = TcpListener::bind(&addr).await?;
 
     tokio::spawn(async move {
         axum::serve(listener, app).await.expect("axum serve failed");


### PR DESCRIPTION
closes #12

Adds support for configuring the web server listening port via the config file.