### PR TITLE
Redirect the calls from the TDC Handler to Mining Server Handler and updates the WebServer state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -305,6 +305,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
@@ -464,6 +470,12 @@ source = "git+https://github.com/stratum-mining/stratum?tag=v1.3.0#6a4874d130232
 dependencies = [
  "aes-gcm",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-slice-cast"
@@ -694,6 +706,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "corepc-client"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +839,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +945,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1259,6 +1313,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls 0.23.27",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1363,113 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1348,6 +1542,12 @@ dependencies = [
  "tracing-subscriber",
  "translator_sv2",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1428,6 +1628,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "json5"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1706,12 @@ name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -1641,8 +1857,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d2aaba477837b46ec1289588180fabfccf0c3b1d1a0c6b1866240cd6cd5ce9"
 dependencies = [
  "log",
- "rustls",
- "rustls-webpki",
+ "rustls 0.21.12",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
  "webpki-roots",
@@ -1657,6 +1873,23 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1762,6 +1995,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,7 +2102,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1898,16 +2175,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "pleblottery"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
  "axum-htmx",
+ "binary_codec_sv2",
  "clap",
  "const_sv2",
  "integration_tests_sv2",
  "once_cell",
+ "reqwest",
  "serde",
  "tokio",
  "toml",
@@ -1964,6 +2249,15 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2094,6 +2388,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,8 +2549,39 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -2222,6 +2591,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2236,6 +2616,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2291,6 +2680,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2436,6 +2848,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,6 +2921,41 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "tap"
@@ -2582,6 +3035,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,6 +3072,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls 0.23.27",
+ "tokio",
 ]
 
 [[package]]
@@ -2898,6 +3381,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2908,6 +3408,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2937,6 +3443,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2980,12 +3567,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2994,7 +3616,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3003,14 +3625,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3020,10 +3658,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3032,10 +3682,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3044,10 +3706,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3056,10 +3730,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -3080,6 +3766,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3097,6 +3789,30 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "synstructure",
 ]
 
 [[package]]
@@ -3140,7 +3856,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,6 @@ axum-htmx = "0.7.0"
 [dev-dependencies]
 integration_tests_sv2 = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }
 const_sv2 = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }
+binary_codec_sv2 = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }
 once_cell = "1.21.3"
+reqwest = "0.12.15"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod config;
 pub mod service;
+pub mod state;
 pub mod sv2_handlers;
 pub mod web;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use tracing::info;
 use pleblottery::cli;
 use pleblottery::config::PleblotteryConfig;
 use pleblottery::service::PlebLotteryService;
+use pleblottery::state::SharedStateHandle;
 use pleblottery::web::server::start_web_server;
 
 #[tokio::main]
@@ -17,14 +18,17 @@ async fn main() -> anyhow::Result<()> {
 
     info!("Config: {:?}", config);
 
+    let shared_state: SharedStateHandle = SharedStateHandle::default();
+
     let mut pleblottery_service = PlebLotteryService::new(
         config.mining_server_config.into(),
         config.template_distribution_config.into(),
+        shared_state.clone(),
     )?;
 
     pleblottery_service.start().await?;
 
-    start_web_server(&config.web_config).await?;
+    start_web_server(&config.web_config, shared_state.clone()).await?;
     info!(
         "Web server started on http://localhost:{}",
         config.web_config.listening_port

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,3 +1,4 @@
+use crate::state::SharedStateHandle;
 use crate::sv2_handlers::mining_server_handler::PlebLotteryMiningServerHandler;
 use crate::sv2_handlers::template_distribution_client_handler::PlebLotteryTemplateDistributionClientHandler;
 use anyhow::{anyhow, Result};
@@ -24,8 +25,9 @@ impl PlebLotteryService {
     pub fn new(
         server_config: Sv2ServerServiceConfig,
         client_config: Sv2ClientServiceConfig,
+        shared_state: SharedStateHandle,
     ) -> Result<Self> {
-        let mining_server_handler = PlebLotteryMiningServerHandler::default();
+        let mining_server_handler = PlebLotteryMiningServerHandler::new(shared_state);
         let template_distribution_client_handler =
             PlebLotteryTemplateDistributionClientHandler::default();
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,18 @@
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+use tower_stratum::roles_logic_sv2::template_distribution_sv2::{NewTemplate, SetNewPrevHash};
+
+#[derive(Default, Debug, Clone)]
+/// Represents the shared state of the application, containing optional
+/// information about the latest template and the latest previous hash.
+///
+/// # Fields
+/// - `latest_template`: An optional `NewTemplate` representing the most recent template.
+/// - `latest_prev_hash`: An optional `SetNewPrevHash` representing the most recent previous hash.
+pub struct SharedState {
+    pub latest_template: Option<NewTemplate<'static>>,
+    pub latest_prev_hash: Option<SetNewPrevHash<'static>>,
+}
+
+pub type SharedStateHandle = Arc<RwLock<SharedState>>;

--- a/src/sv2_handlers/template_distribution_client_handler.rs
+++ b/src/sv2_handlers/template_distribution_client_handler.rs
@@ -1,16 +1,22 @@
 use anyhow::Result;
-use tower_stratum::client::service::request::RequestToSv2ClientError;
+use tower_stratum::client::service::request::{RequestToSv2Client, RequestToSv2ClientError};
 use tower_stratum::client::service::response::ResponseFromSv2Client;
 use tower_stratum::client::service::subprotocols::template_distribution::handler::Sv2TemplateDistributionClientHandler;
 use tower_stratum::roles_logic_sv2::template_distribution_sv2::{
     NewTemplate, RequestTransactionDataError, RequestTransactionDataSuccess, SetNewPrevHash,
 };
-
-use std::task::{Context, Poll};
+use tower_stratum::server::service::request::RequestToSv2Server;
+use tower_stratum::server::service::subprotocols::mining::request::RequestToSv2MiningServer;
 use tracing::info;
 
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::sync::RwLock;
+
 #[derive(Debug, Clone, Default)]
-pub struct PlebLotteryTemplateDistributionClientHandler {}
+pub struct PlebLotteryTemplateDistributionClientHandler {
+    current_height: Arc<RwLock<u64>>,
+}
 
 impl Sv2TemplateDistributionClientHandler for PlebLotteryTemplateDistributionClientHandler {
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), RequestToSv2ClientError>> {
@@ -21,37 +27,53 @@ impl Sv2TemplateDistributionClientHandler for PlebLotteryTemplateDistributionCli
         &self,
         template: NewTemplate<'static>,
     ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
-        info!(
-            "Received NewTemplate message with template id {:?}",
-            template.template_id
+        let current_height = template.coinbase_prefix.to_vec().as_slice()[1..]
+            .iter()
+            .rev()
+            .fold(0, |acc, &byte| (acc << 8) | byte as u64)
+            - 1;
+
+        {
+            let mut height = self.current_height.write().await;
+            if current_height != *height {
+                *height = current_height;
+                info!("New Block Height: {}", current_height);
+            }
+        }
+
+        let response = ResponseFromSv2Client::TriggerNewRequest(
+            RequestToSv2Client::SendRequestToSiblingServerService(Box::new(
+                RequestToSv2Server::MiningTrigger(RequestToSv2MiningServer::NewTemplate(template)),
+            )),
         );
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(response)
     }
 
     async fn handle_set_new_prev_hash(
         &self,
         prev_hash: SetNewPrevHash<'static>,
     ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
-        info!(
-            "Received SetNewPrevHash message with prev hash {:?}",
-            prev_hash.prev_hash
+        let response = ResponseFromSv2Client::TriggerNewRequest(
+            RequestToSv2Client::SendRequestToSiblingServerService(Box::new(
+                RequestToSv2Server::MiningTrigger(RequestToSv2MiningServer::SetNewPrevHash(
+                    prev_hash,
+                )),
+            )),
         );
-        Ok(ResponseFromSv2Client::ToDo)
+        Ok(response)
     }
 
     async fn handle_request_transaction_data_success(
         &self,
         _transaction_data: RequestTransactionDataSuccess<'static>,
     ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
-        info!("Received RequestTransactionDataSuccess message");
-        Ok(ResponseFromSv2Client::ToDo)
+        unimplemented!("handle_request_transaction_data_success should not be called");
     }
 
     async fn handle_request_transaction_data_error(
         &self,
         _error: RequestTransactionDataError<'static>,
     ) -> Result<ResponseFromSv2Client<'static>, RequestToSv2ClientError> {
-        info!("Received RequestTransactionDataError message");
-        Ok(ResponseFromSv2Client::ToDo)
+        unimplemented!("handle_request_transaction_data_error should not be called");
     }
 }

--- a/src/web/routes/api.rs
+++ b/src/web/routes/api.rs
@@ -1,5 +1,6 @@
 use crate::config::PleblotteryConfig;
-use axum::{response::Html, Router};
+use crate::state::SharedStateHandle;
+use axum::{extract::State, response::Html, Router};
 
 pub async fn serve_config_htmx() -> Html<String> {
     match PleblotteryConfig::from_file("./config.toml") {
@@ -70,7 +71,123 @@ pub async fn serve_config_htmx() -> Html<String> {
     }
 }
 
-// Define the router for API routes
-pub fn api_routes() -> Router {
-    Router::new().route("/api/config", axum::routing::get(serve_config_htmx))
+pub async fn get_latest_template(State(shared_state): State<SharedStateHandle>) -> Html<String> {
+    let state = shared_state.read().await;
+    if let Some(template) = &state.latest_template {
+        let rows = format!(
+            r#"
+            <tr>
+                <td>Template ID</td>
+                <td>{}</td>
+            </tr>
+            <tr>
+                <td>Version</td>
+                <td>{}</td>
+            </tr>
+            <tr>
+                <td>Coinbase Value</td>
+                <td>{}</td>
+            </tr>"#,
+            template.template_id,
+            template
+                .version
+                .to_be_bytes()
+                .iter()
+                .map(|byte| format!("{:02x}", byte))
+                .collect::<String>(),
+            template.coinbase_tx_value_remaining as f64 / 100_000_000.0
+        );
+        Html(rows)
+    } else {
+        Html(
+            r#"<tr>
+                <td colspan="4">No template available</td>
+            </tr>"#
+                .to_string(),
+        )
+    }
+}
+
+pub async fn get_latest_prev_hash(State(shared_state): State<SharedStateHandle>) -> Html<String> {
+    let state = shared_state.read().await;
+    let mut rows = String::new();
+
+    if let Some(template) = &state.latest_template {
+        let current_height = template.coinbase_prefix.to_vec().as_slice()[1..]
+            .iter()
+            .rev()
+            .fold(0, |acc, &byte| (acc << 8) | byte as u64)
+            - 1;
+        rows.push_str(&format!(
+            r#"
+            <tr>
+                <td>Height</td>
+                <td>{}</td>
+            </tr>
+            "#,
+            current_height
+        ));
+    } else {
+        rows.push_str(
+            r#"<tr class="bg-red-100">
+                <td colspan="4">No current height available</td>
+            </tr>"#,
+        );
+    }
+
+    if let Some(prev_hash) = &state.latest_prev_hash {
+        rows.push_str(&format!(
+            r#"
+            <tr>
+                <td>Prev Hash</td>
+                <td>{}</td>
+            </tr>
+            <tr>
+                <td>nBits</td>
+                <td>{}</td>
+            </tr>
+            <tr>
+                <td>Target</td>
+                <td>{}</td>
+            </tr>
+            "#,
+            prev_hash
+                .prev_hash
+                .to_vec()
+                .iter()
+                .rev()
+                .map(|byte| format!("{:02x}", byte))
+                .collect::<String>(),
+            format!("{:02x}", prev_hash.n_bits),
+            prev_hash
+                .target
+                .to_vec()
+                .iter()
+                .rev()
+                .map(|byte| format!("{:02x}", byte))
+                .collect::<String>()
+        ));
+    } else {
+        rows.push_str(
+            r#"<tr class="bg-red-100">
+                <td colspan="4">No prev hash available</td>
+            </tr>"#,
+        );
+    }
+
+    Html(rows)
+}
+
+pub fn api_routes(shared_state: SharedStateHandle) -> Router {
+    Router::new()
+        .route("/api/config", axum::routing::get(serve_config_htmx))
+        .route(
+            "/api/latest-template",
+            axum::routing::get(get_latest_template),
+        )
+        .route(
+            "/api/latest-prev-hash",
+            axum::routing::get(get_latest_prev_hash),
+        )
+        .with_state(shared_state)
 }

--- a/src/web/routes/html.rs
+++ b/src/web/routes/html.rs
@@ -36,10 +36,12 @@ pub async fn serve_index() -> Html<&'static str> {
             <br>
             <a href="/">Home</a>
             <br>
+            <a href="/dashboard">Dashboard</a>
+            <br>
             <a href="/config">Configuration</a>
             <br>
             <a href="https://github.com/vinteumorg/pleblottery">Source Code</a>
-            <br><br>
+            <br>
             <hr>
             <br>
             ⛏️ plebs be hashin ⚡
@@ -112,9 +114,113 @@ pub async fn serve_config_html() -> Html<&'static str> {
     )
 }
 
+pub async fn serve_dashboard_html() -> Html<&'static str> {
+    Html(
+        r#"
+        <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>pleblottery - Configuration</title>
+        <style type="text/css">
+            .tg {border-collapse:collapse;border-spacing:0;width:100%;}
+            .tg td, .tg th {border-color:white;border-style:solid;border-width:1px;font-family:Arial, sans-serif;font-size:14px;
+                overflow:hidden;padding:10px 5px;word-break:normal;text-align:left;width:50%;} /* Ensure equal width for all cells */
+            .tg th {
+                font-weight: bold;
+                text-align: center; /* Center-align the table headers */
+            }
+            .tb {}
+            .tb td{border-width: 0}
+            body {background-color:#051426;color:white;margin:0;padding:0;}
+            a {color:white;text-decoration:none;}
+            .container {max-width:1200px;margin:0 auto;padding:20px;}
+            .responsive-table {overflow-x:auto;}
+            .tg tr {height: 50px;} /* Ensure all rows have the same height */
+            @media (max-width: 768px) {
+                .tg td, .tg th {font-size:12px;padding:8px;}
+                .tg th {font-weight:normal;}
+            }
+        </style>
+        <script src="https://unpkg.com/htmx.org"></script>
+    </head>
+    <body>
+        <center>
+            <div class="container" style="background-color:#051426;color:white;"> 
+                <br>
+                <b><span style="color: #3CAD65">$</span> pleblottery <span style="color: #D6AF46">#</span></b>
+                <br><br>
+            </div>
+            <br>
+            <a href="/">Home</a>
+            <br><br>
+            <hr>
+            <div id="block-height-container" class="responsive-table">
+                <table class="tg">
+                    <thead>
+                        <tr>
+                            <th colspan="2">Chain Tip</th>
+                        </tr>
+                    </thead>
+                    <tbody hx-get="/api/latest-prev-hash" hx-trigger="every 2s" hx-target="this" hx-swap="innerHTML">
+                        <tr>
+                            <td>Height</td>
+                            <td>Loading...</td>
+                        </tr>
+                        <tr>
+                            <td>Prev Hash</td>
+                            <td>Loading...</td>
+                        </tr>
+                        <tr>
+                            <td>nBits</td>
+                            <td>Loading...</td>
+                        </tr>
+                        <tr>
+                            <td>Target</td>
+                            <td>Loading...</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+                <br><br>
+            <div id="dashboard-container" class="responsive-table">
+            <table class="tg">
+                    <thead>
+                        <tr>
+                            <th colspan="2">Lastest Template</th>
+                        </tr>
+                    </thead>
+                    <tbody hx-get="/api/latest-template" hx-trigger="every 2s" hx-target="this" hx-swap="innerHTML">
+                        <tr>
+                            <td>Template ID</td>
+                            <td>Loading...</td>
+                        </tr>
+                        <tr>
+                            <td>Version</td>
+                            <td>Loading...</td>
+                        </tr>
+                        <tr>
+                            <td>Coinbase Value</td>
+                            <td>Loading...</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <hr>
+            ⛏️ plebs be hashin ⚡
+            <br><br>
+        </center>
+    </body>
+    </html>
+    "#,
+    )
+}
+
 // Define the router for HTML routes
 pub fn html_routes() -> Router {
     Router::new()
         .route("/", axum::routing::get(serve_index))
         .route("/config", axum::routing::get(serve_config_html))
+        .route("/dashboard", axum::routing::get(serve_dashboard_html))
 }

--- a/src/web/server.rs
+++ b/src/web/server.rs
@@ -4,13 +4,17 @@ use tokio::net::TcpListener;
 use tower_http::services::ServeDir;
 
 use crate::config::PlebLotteryWebConfig;
+use crate::state::SharedStateHandle;
 use crate::web::routes::{api::api_routes, html::html_routes};
 
-pub async fn start_web_server(web_config: &PlebLotteryWebConfig) -> Result<()> {
+pub async fn start_web_server(
+    web_config: &PlebLotteryWebConfig,
+    shared_state: SharedStateHandle,
+) -> Result<()> {
     let app = Router::new()
         .nest_service("/static", ServeDir::new("src/web/assets"))
         .merge(html_routes())
-        .merge(api_routes());
+        .merge(api_routes(shared_state));
 
     let addr = format!("0.0.0.0:{}", web_config.listening_port);
     let listener = TcpListener::bind(&addr).await?;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -35,11 +35,12 @@ fn get_available_port() -> u16 {
 }
 
 pub fn load_config() -> PleblotteryConfig {
-    let available_addr = get_available_address();
+    let mining_server_available_addr = get_available_address();
+    let web_server_available_addr = get_available_address();
 
     PleblotteryConfig {
         mining_server_config: PlebLotteryMiningServerConfig {
-            listening_port: available_addr.port(),
+            listening_port: mining_server_available_addr.port(),
             pub_key: "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
                 .parse()
                 .expect("Invalid public key"),
@@ -54,7 +55,7 @@ pub fn load_config() -> PleblotteryConfig {
             auth_pk: None,
         },
         web_config: PlebLotteryWebConfig {
-            listening_port: 1337,
+            listening_port: web_server_available_addr.port(),
         },
     }
 }

--- a/tests/test_connection_with_sv2_minig_device.rs
+++ b/tests/test_connection_with_sv2_minig_device.rs
@@ -1,6 +1,6 @@
 use const_sv2::{MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS};
 use integration_tests_sv2::*;
-use pleblottery::service::PlebLotteryService;
+use pleblottery::{service::PlebLotteryService, state::SharedStateHandle};
 
 mod common;
 use common::load_config;
@@ -12,9 +12,12 @@ async fn test_connection_with_sv2_minig_device() {
     let mut config = load_config();
     config.template_distribution_config.server_addr = tp_address;
 
+    let shared_state: SharedStateHandle = SharedStateHandle::default();
+
     let mut pleblottery_service = PlebLotteryService::new(
         config.mining_server_config.clone().into(),
         config.template_distribution_config.clone().into(),
+        shared_state,
     )
     .map_err(|e| format!("Failed to create PlebLotteryService: {}", e))
     .expect("Failed to create PlebLotteryService");

--- a/tests/test_shared_state_integration.rs
+++ b/tests/test_shared_state_integration.rs
@@ -1,0 +1,132 @@
+use binary_codec_sv2::{Decodable, Encodable};
+use const_sv2::MESSAGE_TYPE_NEW_TEMPLATE;
+use integration_tests_sv2::{sniffer, start_sniffer, start_template_provider};
+use pleblottery::web::server::start_web_server;
+use pleblottery::{service::PlebLotteryService, state::SharedStateHandle};
+use reqwest::Client;
+mod common;
+use common::load_config;
+use tower_stratum::roles_logic_sv2::parsers::IsSv2Message;
+use tower_stratum::roles_logic_sv2::template_distribution_sv2::SetNewPrevHash;
+
+/// Integration test to verify that the shared state between the PlebLotteryService
+/// and the web server works as expected.
+///
+/// The test sets up:
+/// 1. A simulated Template Provider (with a sniffer to inspect messages),
+/// 2. A PlebLotteryService using shared state,
+/// 3. A web server exposing an API backed by the same shared state.
+///
+/// It checks that after the mining service receives a `SetNewPrevHash` message,
+/// the web server exposes the same data through its `/api/latest-prev-hash` endpoint.
+///
+/// This validates that both components access and reflect the same internal state.
+#[tokio::test]
+async fn test_shared_state_between_service_and_web() {
+    // Start a simulated Template Provider and attach a sniffer to monitor its messages
+    let (_tp, tp_address) = start_template_provider(None);
+    let (tp_sniffer, tp_sniffer_addr) =
+        start_sniffer("".to_string(), tp_address, false, None).await;
+    let mut config = load_config();
+    config.template_distribution_config.server_addr = tp_sniffer_addr;
+
+    // Give sniffer some time to initialize before starting the service
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Initialize and start the mining service with the shared state
+    let shared_state: SharedStateHandle = SharedStateHandle::default();
+
+    let mut pleblottery_service = PlebLotteryService::new(
+        config.mining_server_config.clone().into(),
+        config.template_distribution_config.clone().into(),
+        shared_state.clone(),
+    )
+    .expect("Failed to create PlebLotteryService");
+
+    pleblottery_service
+        .start()
+        .await
+        .expect("Failed to start service");
+
+    // Start the web server with the same shared state
+    start_web_server(&config.web_config, shared_state.clone())
+        .await
+        .unwrap();
+
+    // Wait until a `NewTemplate` message is seen going downstream (from TP to service)
+    tp_sniffer
+        .wait_for_message_type_and_clean_queue(
+            sniffer::MessageDirection::ToDownstream,
+            MESSAGE_TYPE_NEW_TEMPLATE,
+        )
+        .await;
+
+    // Extract the upstream message and parse it as SetNewPrevHash
+    let message = tp_sniffer.next_message_from_upstream().unwrap().1;
+    let mut dst = vec![0; u8::from(message.message_type()) as usize];
+    let _ = message.clone().to_bytes(&mut dst);
+    let set_new_prev_hash = SetNewPrevHash::from_bytes(&mut dst).unwrap();
+
+    // Query the web server for the latest prev_hash via the API
+    let client = Client::new();
+    let resp = client
+        .get(&format!(
+            "http://localhost:{}/api/latest-prev-hash",
+            config.web_config.listening_port
+        ))
+        .send()
+        .await
+        .expect("Failed to query web server");
+
+    // Ensure the server responds successfully
+    assert!(
+        resp.status().is_success(),
+        "Web server returned non-200 status."
+    );
+
+    let resp_text = resp.text().await.expect("Failed to read response text");
+
+    // Assert the response from the web server contains the expected values from the SetNewPrevHash message that was shared via SharedState
+    // This tell us that the web server is correctly reflecting the state updated by the SV2 Handlers
+
+    assert!(
+        resp_text.contains(&format!(
+            "{}",
+            set_new_prev_hash
+                .prev_hash
+                .to_vec()
+                .iter()
+                .rev()
+                .map(|byte| format!("{:02x}", byte))
+                .collect::<String>()
+        )),
+        "Response does not contain expected prev_hash."
+    );
+
+    assert!(
+        resp_text.contains(&format!("{}", set_new_prev_hash.template_id)),
+        "Response does not contain expected template_id."
+    );
+
+    assert!(
+        resp_text.contains(&format!("{}", format!("{:02x}", set_new_prev_hash.n_bits))),
+        "Response does not contain expected n_bits."
+    );
+
+    assert!(
+        resp_text.contains(&format!(
+            "{}",
+            set_new_prev_hash
+                .target
+                .to_vec()
+                .iter()
+                .rev()
+                .map(|byte| format!("{:02x}", byte))
+                .collect::<String>()
+        )),
+        "Response does not contain expected target."
+    );
+
+    // Gracefully shut down the mining service
+    pleblottery_service.shutdown().await.unwrap();
+}

--- a/tests/test_template_provider_connection.rs
+++ b/tests/test_template_provider_connection.rs
@@ -3,7 +3,7 @@ use const_sv2::{
     MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS, MESSAGE_TYPE_SET_NEW_PREV_HASH,
 };
 use integration_tests_sv2::*;
-use pleblottery::service::PlebLotteryService;
+use pleblottery::{service::PlebLotteryService, state::SharedStateHandle};
 
 mod common;
 use common::load_config;
@@ -16,12 +16,15 @@ async fn test_template_provider_connection() {
     let mut config = load_config();
     config.template_distribution_config.server_addr = sniffer_addr;
 
+    let shared_state: SharedStateHandle = pleblottery::state::SharedStateHandle::default();
+
     // Give sniffer time to initialize
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
     let mut pleblottery_service = PlebLotteryService::new(
         config.mining_server_config.clone().into(),
         config.template_distribution_config.clone().into(),
+        shared_state,
     )
     .unwrap();
 

--- a/tests/test_without_template_provider.rs
+++ b/tests/test_without_template_provider.rs
@@ -1,21 +1,40 @@
-use pleblottery::service::PlebLotteryService;
+use pleblottery::{service::PlebLotteryService, state::SharedStateHandle};
 
 mod common;
 use common::load_config;
 
+use std::net::{SocketAddr, TcpListener};
+
 #[tokio::test]
 async fn test_without_template_provider() {
-    let config = load_config();
+    let mut config = load_config();
+
+    // Dynamically bind to an available local port and immediately release it.
+    //
+    // This ensures the chosen port is currently unused and avoids hardcoding
+    // a port, which could be occupied or behave differently across systems.
+    //
+    // When the PlebLotteryService tries to connect to this port, it will fail,
+    // simulating an unreachable template provider in a clean and reliable way.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind to a local port");
+    let unused_addr: SocketAddr = listener.local_addr().expect("Failed to get local address");
+    drop(listener); // Immediately release the port so it's available (but unbound)
+
+    config.template_distribution_config.server_addr = unused_addr;
+
+    let shared_state: SharedStateHandle = SharedStateHandle::default();
 
     let mut pleblottery_service = PlebLotteryService::new(
         config.mining_server_config.clone().into(),
         config.template_distribution_config.clone().into(),
+        shared_state,
     )
     .expect("Failed to create PlebLotteryService");
 
     let result = pleblottery_service.start().await;
+
     assert!(
         result.is_err(),
-        "PlebLotteryService should not start without a template provider"
+        "PlebLotteryService should fail to start when the template provider is unreachable"
     );
 }


### PR DESCRIPTION
Closes #7 and #17.

This PR introduces communication between the `Template Distribution Handler` and the `Mining Server Handler` using the **Sibling IO** feature from `tower_stratum`. Through this mechanism, the handlers now share `NewTemplate` updates and chain tip information using `SetNewPrevHash`.

### Web GUI Integration

The web GUI now reflects these updates in by leveraging a `SharedState` between the `PlebLotteryService` and the web server task. This ensures that template and chain tip updates are visible to the user as they occur.

### Test Updates

- Refactored existing tests to account for changes related to `SharedState`.
- In `test_without_template_provider`, a safeguard was added to ensure the test does not accidentally connect to a running local template provider on the default port (8442). This fixes a issue where the test could silently fail if a provider was active in the background.
- Added a new integration test specifically to cover the `SharedState` feature.