### PR TITLE
feat: add Bitcoin address and network configuration to mining server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,6 +2209,7 @@ dependencies = [
  "axum",
  "axum-htmx",
  "binary_codec_sv2",
+ "bitcoin",
  "clap",
  "const_sv2",
  "integration_tests_sv2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tracing-subscriber = "0.3.19"
 axum = "0.8.3"
 tower-http = { version = "0.6.2", features = ["fs"] }
 axum-htmx = "0.7.0"
+bitcoin = "0.32.6"
 
 [dev-dependencies]
 integration_tests_sv2 = { git = "https://github.com/stratum-mining/stratum", tag = "v1.3.0" }

--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ pub_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 priv_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity = 3600
 inactivity_limit = 3600
+coinbase_output_address = "tb1qw8rnkgnk7s48h6w5c0mg7we7gvzykeyp2sze82"
 
 [template_distribution_config]
 server_addr = "127.0.0.1:8442"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,9 +2,11 @@ use once_cell::sync::Lazy;
 use std::{
     collections::HashSet,
     net::{SocketAddr, TcpListener},
+    str::FromStr,
     sync::Mutex,
 };
 
+use bitcoin::Address;
 use pleblottery::config::{
     PlebLotteryMiningServerConfig, PlebLotteryTemplateDistributionClientConfig,
 };
@@ -49,6 +51,12 @@ pub fn load_config() -> PleblotteryConfig {
                 .expect("Invalid private key"),
             cert_validity: 3600,
             inactivity_limit: 3600,
+            coinbase_output_script: Address::from_str(
+                "bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl",
+            )
+            .unwrap()
+            .assume_checked()
+            .script_pubkey(),
         },
         template_distribution_config: PlebLotteryTemplateDistributionClientConfig {
             server_addr: "127.0.0.1:8442".parse().expect("Invalid server address"),

--- a/tests/test_data/bad_address.toml
+++ b/tests/test_data/bad_address.toml
@@ -1,0 +1,15 @@
+# Bad config: invalid address
+[mining_server_config]
+listening_port = 8332
+pub_key = "9bDuixKmZqAJnrmP746n8zU1wyAQRrus7th9dxnkPg6RzQvCnan"
+priv_key = "zmBEmPhqo3A92FkiLVvyCz6htc3e53ph3ZbD4ASqGaLjwnFLi"
+cert_validity = 3600
+inactivity_limit = 300
+coinbase_output_address = "not_a_real_address"
+
+[template_distribution_config]
+server_addr = "127.0.0.1:1234"
+# auth_pk = null
+
+[web_config]
+listening_port = 8080

--- a/tests/test_data/good_config.toml
+++ b/tests/test_data/good_config.toml
@@ -1,0 +1,14 @@
+# Good config file example
+[mining_server_config]
+listening_port = 8332
+pub_key = "9bDuixKmZqAJnrmP746n8zU1wyAQRrus7th9dxnkPg6RzQvCnan"
+priv_key = "zmBEmPhqo3A92FkiLVvyCz6htc3e53ph3ZbD4ASqGaLjwnFLi"
+cert_validity = 3600
+inactivity_limit = 300
+coinbase_output_address = "tb1qw8rnkgnk7s48h6w5c0mg7we7gvzykeyp2sze82"
+
+[template_distribution_config]
+server_addr = "127.0.0.1:1234"
+
+[web_config]
+listening_port = 8080

--- a/tests/test_load_config_from_disk.rs
+++ b/tests/test_load_config_from_disk.rs
@@ -1,0 +1,31 @@
+use pleblottery::config::PleblotteryConfig;
+
+fn config_path(name: &str) -> std::path::PathBuf {
+    [env!("CARGO_MANIFEST_DIR"), "tests", "test_data", name]
+        .iter()
+        .collect()
+}
+
+#[test]
+fn test_good_config() {
+    let config = PleblotteryConfig::from_file(config_path("good_config.toml"))
+        .expect("Should load good config");
+    assert!(config.mining_server_config.listening_port > 0);
+    assert!(!config
+        .mining_server_config
+        .coinbase_output_script
+        .is_empty());
+    assert_eq!(
+        config
+            .mining_server_config
+            .coinbase_output_script
+            .to_hex_string(),
+        "001471c73b2276f42a7be9d4c3f68f3b3e43044b6481"
+    )
+}
+
+#[test]
+#[should_panic(expected = "Invalid coinbase output address")]
+fn test_bad_address() {
+    let _ = PleblotteryConfig::from_file(config_path("bad_address.toml")).unwrap();
+}


### PR DESCRIPTION
closes #19 ;

introduces support for specifying Bitcoin network and coinbase output address configurations in the mining server. It includes updates to configuration files, validation logic, and unit tests to ensure compatibility with different Bitcoin address types and networks.
