### PR TITLE
Update codebase with changes from SRI and tower-stratum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,7 +330,7 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 [[package]]
 name = "binary_codec_sv2"
 version = "2.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "buffer_sv2",
 ]
@@ -329,7 +338,7 @@ dependencies = [
 [[package]]
 name = "binary_sv2"
 version = "3.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "binary_codec_sv2",
  "derive_codec_sv2",
@@ -466,16 +475,16 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "2.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "aes-gcm",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byte-slice-cast"
@@ -497,9 +506,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -547,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -557,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -569,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -588,7 +597,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 [[package]]
 name = "codec_sv2"
 version = "2.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -606,8 +615,8 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common_messages_sv2"
-version = "5.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+version = "5.0.0"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "binary_sv2",
 ]
@@ -643,11 +652,13 @@ dependencies = [
 [[package]]
 name = "config-helpers"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "miniscript",
  "roles_logic_sv2",
  "serde",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -780,9 +791,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -821,7 +832,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "binary_codec_sv2",
 ]
@@ -893,7 +904,7 @@ dependencies = [
 [[package]]
 name = "error_handling"
 version = "1.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 
 [[package]]
 name = "event-listener"
@@ -973,8 +984,8 @@ dependencies = [
 
 [[package]]
 name = "framing_sv2"
-version = "5.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+version = "5.0.0"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1127,9 +1138,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1313,7 +1324,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1338,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1491,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -1511,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "integration_tests_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "async-channel",
  "config-helpers",
@@ -1522,7 +1533,6 @@ dependencies = [
  "key-utils",
  "mining_device",
  "mining_device_sv1",
- "mining_proxy_sv2",
  "minreq",
  "once_cell",
  "pool_sv2",
@@ -1533,6 +1543,17 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "translator_sv2",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1566,7 +1587,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 [[package]]
 name = "jd_client"
 version = "0.1.4"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "async-channel",
  "async-recursion 0.3.2",
@@ -1584,13 +1605,12 @@ dependencies = [
  "stratum-common",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
 name = "jd_server"
 version = "0.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "async-channel",
  "buffer_sv2",
@@ -1609,13 +1629,12 @@ dependencies = [
  "stratum-common",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
 name = "job_declaration_sv2"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "binary_sv2",
 ]
@@ -1656,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "key-utils"
 version = "1.2.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "bs58",
  "rand 0.8.5",
@@ -1679,9 +1698,9 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags",
  "libc",
@@ -1715,6 +1734,15 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "matchit"
@@ -1753,7 +1781,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_device"
 version = "0.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "async-channel",
  "async-recursion 0.3.2",
@@ -1773,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "mining_device_sv1"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "async-channel",
  "num-bigint",
@@ -1789,39 +1817,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "mining_proxy_sv2"
-version = "0.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
-dependencies = [
- "async-channel",
- "async-recursion 0.3.2",
- "buffer_sv2",
- "clap",
- "config",
- "futures",
- "key-utils",
- "nohash-hasher",
- "once_cell",
- "serde",
- "stratum-common",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "mining_sv2"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "binary_sv2",
 ]
 
 [[package]]
 name = "miniscript"
-version = "12.3.2"
+version = "12.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0760e92feaf4ee26bd2e616f557de64712bf1e75f3b1b218dfb475c0a84c7943"
+checksum = "a1eeb3bbebc87062b99fbb8c9067d30dab85469f4cf12248a2667777cc86b282"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1838,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "minreq"
-version = "2.13.4"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d2aaba477837b46ec1289588180fabfccf0c3b1d1a0c6b1866240cd6cd5ce9"
+checksum = "84885312a86831bff4a3cb04a1e54a3f698407e3274c83249313f194d3e0b678"
 dependencies = [
  "log",
  "rustls 0.21.12",
@@ -1881,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "network_helpers_sv2"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "async-channel",
  "codec_sv2",
@@ -1902,7 +1909,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 [[package]]
 name = "noise_sv2"
 version = "1.4.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -2190,7 +2197,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tower-http",
- "tower-stratum 0.1.0 (git+https://github.com/plebhash/tower-stratum.git?branch=main)",
+ "tower-stratum",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2221,7 +2228,7 @@ dependencies = [
 [[package]]
 name = "pool_sv2"
 version = "0.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "async-channel",
  "async-recursion 1.1.1",
@@ -2238,7 +2245,6 @@ dependencies = [
  "stratum-common",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2378,10 +2384,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.12.20"
+name = "regex"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "reqwest"
+version = "0.12.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2434,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "roles_logic_sv2"
 version = "3.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "bitcoin",
  "chacha20poly1305",
@@ -2464,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "rpc_sv2"
 version = "1.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "base64 0.21.7",
  "hex",
@@ -2525,13 +2575,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -2557,9 +2607,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2814,7 +2864,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stratum-common"
 version = "3.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "network_helpers_sv2",
  "roles_logic_sv2",
@@ -2835,7 +2885,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sv1_api"
 version = "1.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",
@@ -2849,7 +2899,7 @@ dependencies = [
 [[package]]
 name = "sv2-cpu-miner"
 version = "0.1.0"
-source = "git+https://github.com/plebhash/sv2-cpu-miner.git?branch=main#6fedc7e3c43e74f985fae11e770b6a07331671f8"
+source = "git+https://github.com/plebhash/sv2-cpu-miner.git?branch=main#d46ddf84476c49d01ae895284c7c4113fdebb735"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2861,7 +2911,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
- "tower-stratum 0.1.0 (git+https://github.com/plebhash/tower-stratum.git?branch=sri-main)",
+ "tower-stratum",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2961,7 +3011,7 @@ dependencies = [
 [[package]]
 name = "template_distribution_sv2"
 version = "3.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "binary_sv2",
 ]
@@ -3016,17 +3066,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "tracing",
@@ -3060,7 +3112,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.28",
+ "rustls 0.23.29",
  "tokio",
 ]
 
@@ -3181,7 +3233,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "tower-stratum"
 version = "0.1.0"
-source = "git+https://github.com/plebhash/tower-stratum.git?branch=main#35f9af2f80d2d3b59e94babd38fe347b6f1cd277"
+source = "git+https://github.com/plebhash/tower-stratum.git?branch=main#6bd2dbf1cb1d577ad43e3b71f2f0af0b686ca388"
 dependencies = [
  "async-channel",
  "dashmap",
@@ -3189,30 +3241,6 @@ dependencies = [
  "secp256k1 0.28.2",
  "serde",
  "stratum-common",
- "tokio",
- "tokio-util",
- "tower",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tower-stratum"
-version = "0.1.0"
-source = "git+https://github.com/plebhash/tower-stratum.git?branch=sri-main#51d74145a1e7ff499ed6d99ed89a47c8a7d87525"
-dependencies = [
- "async-channel",
- "binary_codec_sv2",
- "binary_sv2",
- "buffer_sv2",
- "codec_sv2",
- "framing_sv2",
- "key-utils",
- "network_helpers_sv2",
- "noise_sv2",
- "roles_logic_sv2",
- "secp256k1 0.28.2",
- "serde",
  "tokio",
  "tokio-util",
  "tower",
@@ -3270,10 +3298,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -3281,13 +3313,14 @@ dependencies = [
 [[package]]
 name = "translator_sv2"
 version = "1.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#05a402153bbead9b6270d2ca3699f81d916575a8"
+source = "git+https://github.com/stratum-mining/stratum?branch=v1.4.0#0b083ab9411a8a4c74421e90134b77410759b6df"
 dependencies = [
  "async-channel",
  "async-recursion 0.3.2",
  "buffer_sv2",
  "clap",
  "config",
+ "config-helpers",
  "error_handling",
  "futures",
  "key-utils",
@@ -3301,7 +3334,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3565,9 +3597,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -3749,9 +3781,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ axum-htmx = "0.7.0"
 bitcoin = "0.32.6"
 
 [dev-dependencies]
-integration_tests_sv2 = { git = "https://github.com/stratum-mining/stratum", branch = "main" }
-binary_codec_sv2 = { git = "https://github.com/stratum-mining/stratum", branch = "main" }
+integration_tests_sv2 = { git = "https://github.com/stratum-mining/stratum", branch = "v1.4.0" }
+binary_codec_sv2 = { git = "https://github.com/stratum-mining/stratum", branch = "v1.4.0" }
 once_cell = "1.21.3"
 reqwest = "0.12.15"
 sv2-cpu-miner = { git = "https://github.com/plebhash/sv2-cpu-miner.git", branch = "main" }


### PR DESCRIPTION
closes #30 

- Lock SRI dependency to `v1.4.0`
- update constructors of channel management in `PlebLotteryMiningServerHandler`